### PR TITLE
bugfix/updatePerson

### DIFF
--- a/src/backend/model/excel.js
+++ b/src/backend/model/excel.js
@@ -249,7 +249,10 @@ const updatePersonInExcel = async (personName, person) => {
   }
 
   const data = await parseInfo();
-  if (data.personnel.find(item => item.name === person.name)) {
+  if (
+    personName !== person.name &&
+    data.personnel.find(item => item.name === person.name)
+  ) {
     throw requestError(409, 'Такий службовець вже існує');
   }
   let personInExcel = data.personnel.find(item => item.name === personName);


### PR DESCRIPTION
Маленький багфікс на оновлення пресоналу, раніше при оновлені людини спрацьовувало тільки на ім'я, а якщо змінити лише посаду, то сварилося що такий службовець вже існує, добавив логічного оператора відпрацьовує як слід